### PR TITLE
dynamic base href so that we can also be called '/launch/'

### DIFF
--- a/src/app/wizard/wizard.module.ts
+++ b/src/app/wizard/wizard.module.ts
@@ -1,5 +1,5 @@
 import {APP_INITIALIZER, NgModule} from "@angular/core";
-import {CommonModule} from "@angular/common";
+import {CommonModule, APP_BASE_HREF} from "@angular/common";
 import {FormsModule} from "@angular/forms";
 
 import {AsciidocIndex, Config, ForgeService, History, NgxForgeModule, TokenProvider} from "ngx-forge";
@@ -85,6 +85,10 @@ import {ModalModule} from "ngx-modal";
     {
       provide: Config,
       useClass: LaunchConfig
+    },
+    {
+      provide: APP_BASE_HREF,
+      useValue: '/' + (window.location.pathname.split('/')[1] || '')
     },
     {
       provide: ForgeService,


### PR DESCRIPTION
@gastaldi this makes the base href dynamic, it can be anything now.

To test:
```bash
$ npm start
```
open `http://localhost:8088/launch/`